### PR TITLE
Setting database connection

### DIFF
--- a/bookdore_rails/Gemfile
+++ b/bookdore_rails/Gemfile
@@ -5,8 +5,8 @@ ruby '2.6.3'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.2.3'
-# Use sqlite3 as the database for Active Record
-gem 'sqlite3'
+# Use PostgreSQL as the database for Active Record
+gem 'pg', '0.18.4'
 # Use Puma as the app server
 gem 'puma', '~> 3.11'
 # Use SCSS for stylesheets

--- a/bookdore_rails/Gemfile.lock
+++ b/bookdore_rails/Gemfile.lock
@@ -106,6 +106,7 @@ GEM
     nio4r (2.3.1)
     nokogiri (1.10.3)
       mini_portile2 (~> 2.4.0)
+    pg (0.18.4)
     public_suffix (3.0.3)
     puma (3.12.1)
     rack (2.0.7)
@@ -168,7 +169,6 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    sqlite3 (1.4.1)
     thor (0.20.3)
     thread_safe (0.3.6)
     tilt (2.0.9)
@@ -201,13 +201,13 @@ DEPENDENCIES
   coffee-rails (~> 4.2)
   jbuilder (~> 2.5)
   listen (>= 3.0.5, < 3.2)
+  pg (= 0.18.4)
   puma (~> 3.11)
   rails (~> 5.2.3)
   sass-rails (~> 5.0)
   selenium-webdriver
   spring
   spring-watcher-listen (~> 2.0.0)
-  sqlite3
   turbolinks (~> 5)
   tzinfo-data
   uglifier (>= 1.3.0)

--- a/bookdore_rails/config/database.yml
+++ b/bookdore_rails/config/database.yml
@@ -1,25 +1,20 @@
-# SQLite version 3.x
-#   gem install sqlite3
-#
-#   Ensure the SQLite 3 gem is defined in your Gemfile
-#   gem 'sqlite3'
-#
 default: &default
-  adapter: sqlite3
-  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  adapter: postgresql
+  encoding: unicode
+  pool: 5
   timeout: 5000
 
 development:
   <<: *default
-  database: db/development.sqlite3
+  database: bookdore_development
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: db/test.sqlite3
+  database: bookdore_test
 
 production:
   <<: *default
-  database: db/production.sqlite3
+  database: bookdore_production


### PR DESCRIPTION
## 何をした？

[『ステップ5: データベースの接続設定（周辺設定）をしよう』](https://github.com/everyleaf/el-training/blob/master/docs/el-training.md#%E3%82%B9%E3%83%86%E3%83%83%E3%83%975-%E3%83%87%E3%83%BC%E3%82%BF%E3%83%99%E3%83%BC%E3%82%B9%E3%81%AE%E6%8E%A5%E7%B6%9A%E8%A8%AD%E5%AE%9A%E5%91%A8%E8%BE%BA%E8%A8%AD%E5%AE%9A%E3%82%92%E3%81%97%E3%82%88%E3%81%86)を行った

## つまずいた所

### Ruby 2.7.0-devで'rails db:create'

1. 'rails new project'
2. 'rails db:create'

でエラー。エラーの内容もよく分からない。
@tjnet もしよかったらアドバイスいただけると助かります:pray:

```
The dependency tzinfo-data (>= 0) will be unused by any of the platforms Bundler is installing for. Bundler is installing for ruby but the dependency is only for x86-mingw32, x86-mswin32, x64-mingw32, java. To add those platforms to the bundle, run `bundle lock --add-platform x86-mingw32 x86-mswin32 x64-mingw32 java`.
Traceback (most recent call last):
	36: from bin/rails:3:in `<main>'
	35: from bin/rails:3:in `load'
	34: from /Users/masegi.sho/moneyforward/sample/bin/spring:15:in `<top (required)>'
	33: from /Users/masegi.sho/.rbenv/versions/2.7.0-dev/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:54:in `require'
	32: from /Users/masegi.sho/.rbenv/versions/2.7.0-dev/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:54:in `require'
	31: from /Users/masegi.sho/.rbenv/versions/2.7.0-dev/lib/ruby/gems/2.7.0/gems/spring-2.0.2/lib/spring/binstub.rb:31:in `<top (required)>'
	30: from /Users/masegi.sho/.rbenv/versions/2.7.0-dev/lib/ruby/gems/2.7.0/gems/spring-2.0.2/lib/spring/binstub.rb:31:in `load'
	29: from /Users/masegi.sho/.rbenv/versions/2.7.0-dev/lib/ruby/gems/2.7.0/gems/spring-2.0.2/bin/spring:49:in `<top (required)>'
	28: from /Users/masegi.sho/.rbenv/versions/2.7.0-dev/lib/ruby/gems/2.7.0/gems/spring-2.0.2/lib/spring/client.rb:30:in `run'
	27: from /Users/masegi.sho/.rbenv/versions/2.7.0-dev/lib/ruby/gems/2.7.0/gems/spring-2.0.2/lib/spring/client/command.rb:7:in `call'
	26: from /Users/masegi.sho/.rbenv/versions/2.7.0-dev/lib/ruby/gems/2.7.0/gems/spring-2.0.2/lib/spring/client/rails.rb:28:in `call'
	25: from /Users/masegi.sho/.rbenv/versions/2.7.0-dev/lib/ruby/gems/2.7.0/gems/spring-2.0.2/lib/spring/client/rails.rb:28:in `load'
	24: from /Users/masegi.sho/moneyforward/sample/bin/rails:8:in `<top (required)>'
	23: from /Users/masegi.sho/moneyforward/sample/bin/rails:8:in `require_relative'
	22: from /Users/masegi.sho/moneyforward/sample/config/boot.rb:4:in `<top (required)>'
	21: from /Users/masegi.sho/moneyforward/sample/config/boot.rb:4:in `require'
	20: from /Users/masegi.sho/.rbenv/versions/2.7.0-dev/lib/ruby/gems/2.7.0/gems/bootsnap-1.4.4/lib/bootsnap/setup.rb:30:in `<top (required)>'
	19: from /Users/masegi.sho/.rbenv/versions/2.7.0-dev/lib/ruby/gems/2.7.0/gems/bootsnap-1.4.4/lib/bootsnap.rb:30:in `setup'
	18: from /Users/masegi.sho/.rbenv/versions/2.7.0-dev/lib/ruby/gems/2.7.0/gems/bootsnap-1.4.4/lib/bootsnap/compile_cache.rb:9:in `setup'
	17: from /Users/masegi.sho/.rbenv/versions/2.7.0-dev/lib/ruby/gems/2.7.0/gems/bootsnap-1.4.4/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:48:in `require_relative'
	16: from /Users/masegi.sho/.rbenv/versions/2.7.0-dev/lib/ruby/gems/2.7.0/gems/activesupport-5.2.3/lib/active_support/dependencies.rb:291:in `require'
	15: from /Users/masegi.sho/.rbenv/versions/2.7.0-dev/lib/ruby/gems/2.7.0/gems/activesupport-5.2.3/lib/active_support/dependencies.rb:257:in `load_dependency'
	14: from /Users/masegi.sho/.rbenv/versions/2.7.0-dev/lib/ruby/gems/2.7.0/gems/activesupport-5.2.3/lib/active_support/dependencies.rb:291:in `block in require'
	13: from /Users/masegi.sho/.rbenv/versions/2.7.0-dev/lib/ruby/gems/2.7.0/gems/bootsnap-1.4.4/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
	12: from /Users/masegi.sho/.rbenv/versions/2.7.0-dev/lib/ruby/gems/2.7.0/gems/bootsnap-1.4.4/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:21:in `require_with_bootsnap_lfi'
	11: from /Users/masegi.sho/.rbenv/versions/2.7.0-dev/lib/ruby/gems/2.7.0/gems/bootsnap-1.4.4/lib/bootsnap/load_path_cache/loaded_features_index.rb:92:in `register'
	10: from /Users/masegi.sho/.rbenv/versions/2.7.0-dev/lib/ruby/gems/2.7.0/gems/bootsnap-1.4.4/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:22:in `block in require_with_bootsnap_lfi'
	 9: from /Users/masegi.sho/.rbenv/versions/2.7.0-dev/lib/ruby/gems/2.7.0/gems/bootsnap-1.4.4/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:22:in `require'
	 8: from /Users/masegi.sho/.rbenv/versions/2.7.0-dev/lib/ruby/gems/2.7.0/gems/bootsnap-1.4.4/lib/bootsnap/compile_cache/iseq.rb:1:in `<top (required)>'
	 7: from /Users/masegi.sho/.rbenv/versions/2.7.0-dev/lib/ruby/gems/2.7.0/gems/activesupport-5.2.3/lib/active_support/dependencies.rb:291:in `require'
	 6: from /Users/masegi.sho/.rbenv/versions/2.7.0-dev/lib/ruby/gems/2.7.0/gems/activesupport-5.2.3/lib/active_support/dependencies.rb:257:in `load_dependency'
	 5: from /Users/masegi.sho/.rbenv/versions/2.7.0-dev/lib/ruby/gems/2.7.0/gems/activesupport-5.2.3/lib/active_support/dependencies.rb:291:in `block in require'
	 4: from /Users/masegi.sho/.rbenv/versions/2.7.0-dev/lib/ruby/gems/2.7.0/gems/bootsnap-1.4.4/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
	 3: from /Users/masegi.sho/.rbenv/versions/2.7.0-dev/lib/ruby/gems/2.7.0/gems/bootsnap-1.4.4/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:21:in `require_with_bootsnap_lfi'
	 2: from /Users/masegi.sho/.rbenv/versions/2.7.0-dev/lib/ruby/gems/2.7.0/gems/bootsnap-1.4.4/lib/bootsnap/load_path_cache/loaded_features_index.rb:92:in `register'
	 1: from /Users/masegi.sho/.rbenv/versions/2.7.0-dev/lib/ruby/gems/2.7.0/gems/bootsnap-1.4.4/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:22:in `block in require_with_bootsnap_lfi'
/Users/masegi.sho/.rbenv/versions/2.7.0-dev/lib/ruby/gems/2.7.0/gems/bootsnap-1.4.4/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:22:in `require': no implicit conversion of String into Integer (TypeError)
```

## Postgresに接続していなかった。

```.zsh
export PGDATA='/usr/local/var/postgres'
```
を'~/.zshrc'に追記。
```
postgres
```
してないとこんなエラーが出る。

```
could not connect to server: No such file or directory
	Is the server running locally and accepting
	connections on Unix domain socket "/tmp/.s.PGSQL.5432"?
Couldn't create 'bookdore_development' database. Please check your configuration.
rails aborted!
PG::ConnectionBad: could not connect to server: No such file or directory
	Is the server running locally and accepting
	connections on Unix domain socket "/tmp/.s.PGSQL.5432"?
/Users/masegi.sho/moneyforward/Bookdore/bookdore_rails/bin/rails:9:in `<top (required)>'
/Users/masegi.sho/moneyforward/Bookdore/bookdore_rails/bin/spring:15:in `<top (required)>'
bin/rails:3:in `load'
bin/rails:3:in `<main>'
Tasks: TOP => db:create
(See full trace by running task with --trace)
```