### PR TITLE
Change status type, string to enum(int)

### DIFF
--- a/app/models/card.rb
+++ b/app/models/card.rb
@@ -1,4 +1,5 @@
 class Card < ApplicationRecord
+  enum status: [:want, :bought, :reading, :read]
   validates :book,
             presence: true,
             length: { maximum: 50 },

--- a/app/views/cards/edit.html.erb
+++ b/app/views/cards/edit.html.erb
@@ -10,7 +10,7 @@
       <%= form.text_field :book, class: 'form-control' %>
 
       <%= form.label :status %>
-      <%= form.text_field :status, class: 'form-control' %>
+      <%= form.select :status, Card.statuses.keys.to_a, class: 'form-control', id: 'form_status' %>
 
       <%= form.label :deadline %>
       <%= form.text_field :deadline, data: { date_format: "YYYY-MM-DD HH:mm:ss"}, class: 'form-control', placeholder: 'YYYY-MM-DD HH:mm:ss', id: 'datetimepicker4' %>

--- a/app/views/cards/edit.html.erb
+++ b/app/views/cards/edit.html.erb
@@ -10,7 +10,7 @@
       <%= form.text_field :book, class: 'form-control' %>
 
       <%= form.label :status %>
-      <%= form.select :status, Card.statuses.keys.to_a, class: 'form-control', id: 'form_status' %>
+      <%= form.select :status, Card.statuses.keys.to_a, {}, class: 'form-control', id: 'form_status' %>
 
       <%= form.label :deadline %>
       <%= form.text_field :deadline, data: { date_format: "YYYY-MM-DD HH:mm:ss"}, class: 'form-control', placeholder: 'YYYY-MM-DD HH:mm:ss', id: 'datetimepicker4' %>

--- a/app/views/cards/new.html.erb
+++ b/app/views/cards/new.html.erb
@@ -9,7 +9,7 @@
       <%= form.text_field :book, class: 'form-control', id: 'form_book' %>
 
       <%= form.label :status %>
-      <%= form.select :status, Card.statuses.keys.to_a, class: 'form-control', id: 'form_status' %>
+      <%= form.select :status, Card.statuses.keys.to_a, {}, class: 'form-control', id: 'form_status' %>
 
       <%= form.label :deadline %>
       <%= form.text_field :deadline, data: { date_format: "YYYY-MM-DD HH:mm:ss"}, class: 'form-control', placeholder: 'YYYY-MM-DD HH:mm:ss', id: 'form_deadline' %>

--- a/app/views/cards/new.html.erb
+++ b/app/views/cards/new.html.erb
@@ -9,7 +9,7 @@
       <%= form.text_field :book, class: 'form-control', id: 'form_book' %>
 
       <%= form.label :status %>
-      <%= form.text_field :status, class: 'form-control', id: 'form_status' %>
+      <%= form.select :status, Card.statuses.keys.to_a, class: 'form-control', id: 'form_status' %>
 
       <%= form.label :deadline %>
       <%= form.text_field :deadline, data: { date_format: "YYYY-MM-DD HH:mm:ss"}, class: 'form-control', placeholder: 'YYYY-MM-DD HH:mm:ss', id: 'form_deadline' %>

--- a/db/migrate/20190514071223_change_column_to_int_to_card.rb
+++ b/db/migrate/20190514071223_change_column_to_int_to_card.rb
@@ -1,0 +1,10 @@
+class ChangeColumnToIntToCard < ActiveRecord::Migration[5.2]
+  def up
+    remove_column :cards, :status, :integer
+    add_column :cards, :status, :integer, null: false, default: 0
+  end
+
+  def down
+    change_column :cards, :status, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,17 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_13_024840) do
+ActiveRecord::Schema.define(version: 2019_05_14_071223) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "cards", force: :cascade do |t|
     t.string "book"
-    t.string "status"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.datetime "deadline"
+    t.string "deadline"
+    t.integer "status", default: 0, null: false
   end
 
 end

--- a/spec/system/cards_spec.rb
+++ b/spec/system/cards_spec.rb
@@ -9,7 +9,7 @@ describe 'Card create action: ', type: :system do
     before do
       visit new_card_path
       fill_in 'form_book', with: "Test Book"
-      fill_in 'form_status', with: "Test Status"
+      find('#form_status').find(:xpath, 'option[2]').select_option
       fill_in 'form_deadline', with: "2020-01-01 00:00:00"
       click_button "Create new card"
     end


### PR DESCRIPTION

## References
- [Capybaraチートシート](https://qiita.com/morrr/items/0e24251c049180218db4)
- [railsでf.selectにclassを設定する](https://qiita.com/nakanoyoshiki/items/e87a6238f8febbeb208a)
- [How to select option in drop down using Capybara
](https://stackoverflow.com/questions/20134085/how-to-select-option-in-drop-down-using-capybara)

## Overviews

- `Card#status`に関しては以下の４つしかないので`string`ではなく`enum(int)`を使うようにした。
    - `読みたい`
    - `買った（積読状態）`
    - `読んでいる`
    - `読んだ`

## Technical Overviews

- DBのcolumnを変更
    - 既存の`status` カラムがあったので、それの型を変更
    - 既存のレコードは `status` カラムの値を全てdefaultの`読みたい`状態に修正
- CardのCreate画面で `status` 選択を`Pull down`方式に変更
- Create card actionのsystemテストを修正

## UI Change Point

<img width="663" alt="スクリーンショット 2019-05-15 15 08 07" src="https://user-images.githubusercontent.com/12663296/57752233-64c98580-7723-11e9-8cc5-88764d7b9532.png">
<img width="663" alt="スクリーンショット 2019-05-15 15 08 18" src="https://user-images.githubusercontent.com/12663296/57752238-685d0c80-7723-11e9-8d9b-9b181b798d4a.png">

## Test Point/Result

* [ ] カード作成のシステムテスト
- `bundle exec rspec spec/system/cards_spec.rb`


## Other

- システムテストの際、`Pull down`の値を変更する方法を知りたい